### PR TITLE
Make library reference multiplatform

### DIFF
--- a/Src/IPL.cs
+++ b/Src/IPL.cs
@@ -5,7 +5,7 @@
 	/// </summary>
 	public static partial class IPL
 	{
-		public const string Library = "phonon.dll";
+		public const string Library = "phonon";
 
 		public partial struct Vector3
 		{


### PR DESCRIPTION
This allows the runtime to automatically resolve extension - e.g. .so on Linux instead of .dll